### PR TITLE
Change Relation Macros for Mongoid 3.0 support

### DIFF
--- a/lib/mongoid_nested_set/base.rb
+++ b/lib/mongoid_nested_set/base.rb
@@ -48,8 +48,8 @@ module Mongoid::Acts::NestedSet
         field outline_number_field_name, :type => String if outline_number_field_name
         field :depth, :type => Integer
 
-        has_many :children, :class_name => self.name, :foreign_key => parent_field_name, :inverse_of => :parent, :order => criteria.asc(left_field_name)
-        belongs_to   :parent,   :class_name => self.name, :foreign_key => parent_field_name
+        has_many   :children, :class_name => self.name, :foreign_key => parent_field_name, :inverse_of => :parent, :order => criteria.asc(left_field_name)
+        belongs_to :parent,   :class_name => self.name, :foreign_key => parent_field_name
 
         attr_accessor :skip_before_destroy
 

--- a/lib/mongoid_nested_set/base.rb
+++ b/lib/mongoid_nested_set/base.rb
@@ -48,8 +48,8 @@ module Mongoid::Acts::NestedSet
         field outline_number_field_name, :type => String if outline_number_field_name
         field :depth, :type => Integer
 
-        references_many :children, :class_name => self.name, :foreign_key => parent_field_name, :inverse_of => :parent, :order => criteria.asc(left_field_name)
-        referenced_in   :parent,   :class_name => self.name, :foreign_key => parent_field_name
+        has_many :children, :class_name => self.name, :foreign_key => parent_field_name, :inverse_of => :parent, :order => criteria.asc(left_field_name)
+        belongs_to   :parent,   :class_name => self.name, :foreign_key => parent_field_name
 
         attr_accessor :skip_before_destroy
 


### PR DESCRIPTION
See https://github.com/mongoid/mongoid/issues/1270

Should not affect 2.x as far as belongs_to and has_many was aliased to referenced_in and references_many before.
