### PR TITLE
Criteria#fuse method will be removed since Mongoid 3.0

### DIFF
--- a/lib/mongoid_nested_set/update.rb
+++ b/lib/mongoid_nested_set/update.rb
@@ -208,19 +208,19 @@ module Mongoid::Acts::NestedSet
           model.destroy
         end
       else
-        c = nested_set_scope.fuse(:where => {left_field_name => {"$gt" => left}, right_field_name => {"$lt" => right}})
+        c = nested_set_scope.merge(scope_class.where(left_field_name => {"$gt" => left}, right_field_name => {"$lt" => right}))
         scope_class.delete_all(:conditions => c.selector)
       end
 
       # update lefts and rights for remaining nodes
       diff = right - left + 1
       scope_class.collection.update(
-        nested_set_scope.fuse(:where => {left_field_name => {"$gt" => right}}).selector,
+        nested_set_scope.merge(scope_class.where(left_field_name => {"$gt" => right})).selector,
         {"$inc" => { left_field_name => -diff }},
         {:safe => true, :multi => true}
       )
       scope_class.collection.update(
-        nested_set_scope.fuse(:where => {right_field_name => {"$gt" => right}}).selector,
+        nested_set_scope.merge(scope_class.where(right_field_name => {"$gt" => right})).selector,
         {"$inc" => { right_field_name => -diff }},
         {:safe => true, :multi => true}
       )


### PR DESCRIPTION
According to mongoid/mongoid@8578dd7fc112e783f869ffcbc510727a3bc0cef4 `Criteria#fuse` method will be removed since Mongoid 3.0 and `Criteria#merge` will only accept another criteria but hash so `fuse` calls were replaced with corresponding `merge`s. Should be compatible with Mongoid 2 as far as `Criteria#merge` was accepting `Criteria` before. 
