### PR TITLE
Order option on association and Mongoid 3

### DIFF
--- a/lib/mongoid_nested_set/base.rb
+++ b/lib/mongoid_nested_set/base.rb
@@ -48,7 +48,7 @@ module Mongoid::Acts::NestedSet
         field outline_number_field_name, :type => String if outline_number_field_name
         field :depth, :type => Integer
 
-        has_many   :children, :class_name => self.name, :foreign_key => parent_field_name, :inverse_of => :parent, :order => criteria.asc(left_field_name)
+        has_many   :children, :class_name => self.name, :foreign_key => parent_field_name, :inverse_of => :parent, :order => left_field_name.to_sym.asc
         belongs_to :parent,   :class_name => self.name, :foreign_key => parent_field_name
 
         attr_accessor :skip_before_destroy


### PR DESCRIPTION
As far as mongoid 3 using Origin DSL, only this sorting options could be used: https://github.com/mongoid/origin/blob/master/lib/origin/optional.rb#L134

So, changed :order option for children, otherwise children will fail on new mongoid.

This syntax also does not fail on mongoid 2 according to my tests.
