### PR TITLE
remove_order_by method was broken for newest mongoid

### DIFF
--- a/lib/mongoid_nested_set/remove_order_by.rb
+++ b/lib/mongoid_nested_set/remove_order_by.rb
@@ -1,11 +1,15 @@
 module Mongoid
   module Criterion
-    module Optional
+    module Ordering
       def remove_order_by
         @options[:sort] = nil
         self
       end
     end
+  end
+
+  class Criteria
+    include Criterion::Ordering
   end
 end
 


### PR DESCRIPTION
Mongoid::Criterion::Optional module (which was included in Mongoid::Criteria class) was dropped in mongoid 3, so remove_order_by method stopped working. As far as there is no relevant module in Criterion to attach to, I renamed Optional to Ordering (to correspond current naming scheme (mongoid has Inspection and Scoping as for now)) and included it explicitly in Criteria.
