### PR TITLE
remove_order_by in set_default_left_and_right

### DIFF
--- a/lib/mongoid_nested_set/update.rb
+++ b/lib/mongoid_nested_set/update.rb
@@ -65,7 +65,7 @@ module Mongoid::Acts::NestedSet
 
     # on creation, set automatically lft and rgt to the end of the tree
     def set_default_left_and_right
-      maxright = nested_set_scope.max(right_field_name) || 0
+      maxright = nested_set_scope.remove_order_by.max(right_field_name) || 0
       self[left_field_name] = maxright + 1
       self[right_field_name] = maxright + 2
       self[:depth] = 0


### PR DESCRIPTION
I've got this nasty thing and a bunch of failing specs with mongoid 3.0.9. This seems to fix it.

The operation: #<Moped::Protocol::Command
  @length=966
  @request_id=18
  @response_to=0
  @op_code=2004
  @flags=[]
  @full_collection_name="hot_tea.$cmd"
  @skip=0
  @limit=-1
  @selector={:mapreduce=>"reviews", :map=>"\n          function() {\n            var agg = {\n              count: 1,\n              max: this.rgt,\n              min: this.rgt,\n              sum: this.rgt\n            };\n            emit(\"rgt\", agg);\n          }", :reduce=>"\n          function(key, values) {\n            var agg = { count: 0, max: null, min: null, sum: 0 };\n            values.forEach(function(val) {\n              if (val.max !== null) {\n                if (agg.max == null || val.max > agg.max) agg.max = val.max;\n                if (agg.min == null || val.max < agg.min) agg.min = val.max;\n                agg.sum += val.sum;\n              }\n              agg.count += 1;\n            });\n            return agg;\n          }", :query=>{"deleted_at"=>nil}, :sort=>{"lft"=>1}, :out=>{:inline=>1}, :finalize=>"\n          function(key, agg) {\n            agg.avg = agg.sum / agg.count;\n            return agg;\n          }"}
  @fields=nil>
failed with error 16052: "exception: could not create cursor over hot_tea.reviews for query : { deleted_at: null } sort : { lft: 1 }"

See https://github.com/mongodb/mongo/blob/master/docs/errors.md
for details about this error.
